### PR TITLE
Refactor of Processor and Other Changes

### DIFF
--- a/cmd/zrule/autocomplete.go
+++ b/cmd/zrule/autocomplete.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 
-	"github.com/eveisesi/zrule"
 	"github.com/eveisesi/zrule/internal/search"
 	"github.com/jinzhu/copier"
 )
@@ -74,7 +73,7 @@ func initializeAutocompleter(basics *app, repos repositories, searchServ search.
 	entry = basics.logger.WithField("autocompleter", "itemGroups")
 	entry.Info("initializing autocompleter")
 
-	itemGroups, _ := repos.itemGroup.ItemGroups(ctx, zrule.NewEqualOperator("category", 6))
+	itemGroups, _ := repos.itemGroup.ItemGroups(ctx)
 	entities = make([]*search.Entity, len(itemGroups))
 	for i, group := range itemGroups {
 		entity := new(search.Entity)
@@ -106,6 +105,27 @@ func initializeAutocompleter(basics *app, repos repositories, searchServ search.
 		entities[i] = entity
 	}
 	err = searchServ.InitializeAutocompleter(search.KeyItems, entities)
+	if err != nil {
+		entry.WithError(err).Fatal("failed to initialize autocompleter")
+	}
+
+	entry.Info("autocompleter initialized successfully")
+
+	entry = basics.logger.WithField("autocompleter", "factions")
+	entry.Info("initializing autocompleter")
+
+	factions, _ := repos.faction.Factions(ctx)
+	entities = make([]*search.Entity, len(factions))
+	for i, faction := range factions {
+		entity := new(search.Entity)
+		err = copier.Copy(entity, faction)
+		if err != nil {
+			basics.logger.WithError(err).Error("failed to copy region to generic entity")
+			continue
+		}
+		entities[i] = entity
+	}
+	err = searchServ.InitializeAutocompleter(search.KeyFactions, entities)
 	if err != nil {
 		entry.WithError(err).Fatal("failed to initialize autocompleter")
 	}

--- a/cmd/zrule/initialize.go
+++ b/cmd/zrule/initialize.go
@@ -80,7 +80,7 @@ func initializeCommand(c *cli.Context) {
 	basics.logger.Info("groups and items imported successfully")
 
 	regions, m := esiServ.GetUniverseRegions(ctx)
-	if err != nil {
+	if m.IsErr() {
 		basics.logger.WithError(m.Msg).Error("failed to fetch regions from ESI")
 		return
 	}
@@ -138,6 +138,21 @@ func initializeCommand(c *cli.Context) {
 			basics.logger.WithField("regionID", regionID).Info("region saved successfully")
 		}(basics, wg, regionID)
 
+	}
+
+	factions, m := esiServ.GetUniverseFactions(ctx)
+	if m.IsErr() {
+		basics.logger.WithError(m.Msg).Error("failed to fetch factions from ESI")
+		return
+	}
+
+	for _, faction := range factions {
+		faction.ID = faction.ESIID
+		faction, err = universe.CreateFaction(ctx, faction)
+		if err != nil {
+			basics.logger.WithError(err).WithField("factionID", faction.ID).Error("failed to save faction to database")
+			return
+		}
 	}
 
 	wg.Wait()

--- a/cmd/zrule/processor.go
+++ b/cmd/zrule/processor.go
@@ -19,14 +19,16 @@ func processorCommand(c *cli.Context) {
 	basics.logger.Info("policyRepo initialized")
 	repos := initializeRepositories(basics)
 
+	universeServ := newUniverseService(basics, repos)
+
 	err = processor.NewService(
 		basics.redis,
 		basics.logger,
 		basics.newrelic,
-		policy.NewService(newUniverseService(basics, repos), policyRepo),
+		policy.NewService(universeServ, policyRepo),
+		universeServ,
 	).Run(5)
 	if err != nil {
 		basics.logger.WithError(err).Fatal("failed to start processor service")
 	}
-
 }

--- a/cmd/zrule/repositories.go
+++ b/cmd/zrule/repositories.go
@@ -9,6 +9,7 @@ type repositories struct {
 	alliance      zrule.AllianceRepository
 	character     zrule.CharacterRepository
 	corporation   zrule.CorporationRepository
+	faction       zrule.FactionRepository
 	region        zrule.RegionRepository
 	constellation zrule.ConstellationRepository
 	system        zrule.SolarSystemRepository
@@ -33,6 +34,13 @@ func initializeRepositories(basics *app) repositories {
 	}
 
 	basics.logger.Info("charactersRepo initialized")
+
+	repos.faction, err = mdb.NewFactionRepository(basics.db)
+	if err != nil {
+		basics.logger.WithError(err).Fatal("failed to initialize factionsRepo")
+	}
+
+	basics.logger.Info("factionsRepo initialized")
 
 	repos.constellation, err = mdb.NewConstellationRepository(basics.db)
 	if err != nil {

--- a/cmd/zrule/universe.go
+++ b/cmd/zrule/universe.go
@@ -12,7 +12,7 @@ func newUniverseService(basics *app, repos repositories) universe.Service {
 		basics.redis, basics.newrelic, esiServ,
 		repos.alliance, repos.corporation, repos.character,
 		repos.region, repos.constellation, repos.system,
-		repos.item, repos.itemGroup,
+		repos.faction, repos.item, repos.itemGroup,
 	)
 
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/jinzhu/copier v0.0.0-20201025035756-632e723a6687
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/korovkin/limiter v0.0.0-20190919045942-dac5a6b2a536
 	github.com/lestrrat-go/jwx v0.9.2
 	github.com/newrelic/go-agent/v3 v3.9.0
 	github.com/newrelic/go-agent/v3/integrations/logcontext/nrlogrusplugin v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,6 @@ github.com/klauspost/compress v1.9.5 h1:U+CaK85mrNNb4k8BNOfgJtJ/gr6kswUCFj6miSzV
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/korovkin/limiter v0.0.0-20190919045942-dac5a6b2a536 h1:QwKnpk6xFW80HVFKqiIHTzK19UF62mRWejcUr/q6z4I=
-github.com/korovkin/limiter v0.0.0-20190919045942-dac5a6b2a536/go.mod h1:bttpekv26JrhFNCYlxnxn8a1jw8Q0gi8iHe0RC4JLBg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -189,8 +187,6 @@ github.com/lestrrat-go/jwx v0.9.2/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/Y
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
-github.com/newrelic/go-agent v1.11.0 h1:jnd8+H6dB+93UTJHFT1wJoij5spKNN/xZ0nkw0kvt7o=
-github.com/newrelic/go-agent v3.9.0+incompatible h1:W2Zummx9jNATZVX6QVjYksX1TwxJGf4E6x1Wf3CG/jY=
 github.com/newrelic/go-agent/v3 v3.0.0/go.mod h1:H28zDNUC0U/b7kLoY4EFOhuth10Xu/9dchozUiOseQQ=
 github.com/newrelic/go-agent/v3 v3.9.0 h1:5bcTbdk/Up5cIYIkQjCG92Y+uNoett9wmhuz4kPiFlM=
 github.com/newrelic/go-agent/v3 v3.9.0/go.mod h1:1A1dssWBwzB7UemzRU6ZVaGDsI+cEn5/bNxI0wiYlIc=

--- a/internal/esi/factions.go
+++ b/internal/esi/factions.go
@@ -1,0 +1,51 @@
+package esi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/eveisesi/zrule"
+)
+
+type factionService interface {
+	GetUniverseFactions(ctx context.Context) ([]*zrule.Faction, Meta)
+}
+
+func (s *service) GetUniverseFactions(ctx context.Context) ([]*zrule.Faction, Meta) {
+
+	path := "/v2/universe/factions/"
+
+	request := request{
+		method:  http.MethodGet,
+		path:    path,
+		headers: make(map[string]string),
+	}
+
+	response, m := s.request(ctx, request)
+	if m.IsErr() {
+		return nil, m
+	}
+
+	factions := make([]*zrule.Faction, 0)
+
+	switch m.Code {
+	case 200:
+		err := json.Unmarshal(response, &factions)
+		if err != nil {
+			m.Msg = fmt.Errorf("unable to unmarshal response body on request %s: %w", path, err)
+			return nil, m
+		}
+
+		for _, faction := range factions {
+			faction.ID = faction.ESIID
+		}
+	default:
+		m.Msg = fmt.Errorf("unexpected status code received from ESI on request %s", path)
+
+	}
+
+	return factions, m
+
+}

--- a/internal/esi/service.go
+++ b/internal/esi/service.go
@@ -32,6 +32,7 @@ type (
 		constellationService
 		corporationService
 		itemService
+		factionService
 		regionService
 		searchService
 		solarSystemService

--- a/internal/http/actions.go
+++ b/internal/http/actions.go
@@ -146,68 +146,68 @@ func (s *server) handleCreateAction(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func (s *server) handleUpdateAction(w http.ResponseWriter, r *http.Request) {
+// func (s *server) handleUpdateAction(w http.ResponseWriter, r *http.Request) {
 
-	var ctx = r.Context()
+// 	var ctx = r.Context()
 
-	actionID := chi.URLParam(r, "actionID")
-	if actionID == "" {
-		s.writeError(w, http.StatusBadRequest, fmt.Errorf("actionID is required to perform an update"))
-		return
-	}
+// 	actionID := chi.URLParam(r, "actionID")
+// 	if actionID == "" {
+// 		s.writeError(w, http.StatusBadRequest, fmt.Errorf("actionID is required to perform an update"))
+// 		return
+// 	}
 
-	entry := s.logger.WithField("actionID", actionID)
+// 	entry := s.logger.WithField("actionID", actionID)
 
-	user := UserFromContext(ctx)
-	if user == nil {
-		err := fmt.Errorf("ctx does not contain a user")
-		entry.WithError(err).Errorln()
-		s.writeError(w, http.StatusInternalServerError, nil)
-		return
-	}
+// 	user := UserFromContext(ctx)
+// 	if user == nil {
+// 		err := fmt.Errorf("ctx does not contain a user")
+// 		entry.WithError(err).Errorln()
+// 		s.writeError(w, http.StatusInternalServerError, nil)
+// 		return
+// 	}
 
-	objectID, err := primitive.ObjectIDFromHex(actionID)
-	if err != nil {
-		msg := "provided action id is invalid"
-		entry.WithError(err).Error(msg)
-		s.writeError(w, http.StatusBadRequest, fmt.Errorf(msg))
-		return
-	}
+// 	objectID, err := primitive.ObjectIDFromHex(actionID)
+// 	if err != nil {
+// 		msg := "provided action id is invalid"
+// 		entry.WithError(err).Error(msg)
+// 		s.writeError(w, http.StatusBadRequest, fmt.Errorf(msg))
+// 		return
+// 	}
 
-	entry = entry.WithField("ownerID", user.ID)
+// 	entry = entry.WithField("ownerID", user.ID)
 
-	actions, err := s.action.Actions(ctx, zrule.NewEqualOperator("owner_id", user.ID), zrule.NewEqualOperator("_id", objectID))
-	if err != nil {
-		entry.WithError(err).Error("failed to find action for provided actionID")
-		s.writeError(w, http.StatusBadRequest, fmt.Errorf("failed to find action for provided actionID"))
-		return
-	}
+// 	actions, err := s.action.Actions(ctx, zrule.NewEqualOperator("owner_id", user.ID), zrule.NewEqualOperator("_id", objectID))
+// 	if err != nil {
+// 		entry.WithError(err).Error("failed to find action for provided actionID")
+// 		s.writeError(w, http.StatusBadRequest, fmt.Errorf("failed to find action for provided actionID"))
+// 		return
+// 	}
 
-	if len(actions) == 0 || len(actions) > 1 {
-		entry.WithError(err).Error("matched multiple actions for query")
-		s.writeError(w, http.StatusInternalServerError, fmt.Errorf("matched multiple actions for query"))
-		return
-	}
+// 	if len(actions) == 0 || len(actions) > 1 {
+// 		entry.WithError(err).Error("matched multiple actions for query")
+// 		s.writeError(w, http.StatusInternalServerError, fmt.Errorf("matched multiple actions for query"))
+// 		return
+// 	}
 
-	action := actions[0]
+// 	action := actions[0]
 
-	err = json.NewDecoder(r.Body).Decode(&action)
-	if err != nil {
-		entry.WithError(err).Error("failed to decode response")
-		s.writeError(w, http.StatusBadRequest, fmt.Errorf("failed to decode response: %w", err))
-		return
-	}
+// 	err = json.NewDecoder(r.Body).Decode(&action)
+// 	if err != nil {
+// 		entry.WithError(err).Error("failed to decode response")
+// 		s.writeError(w, http.StatusBadRequest, fmt.Errorf("failed to decode response: %w", err))
+// 		return
+// 	}
 
-	action, err = s.action.UpdateAction(ctx, objectID, action)
-	if err != nil {
-		entry.WithError(err).Error("failed to update action")
-		s.writeError(w, http.StatusBadRequest, fmt.Errorf("failed to update action: %w", err))
-		return
-	}
+// 	action, err = s.action.UpdateAction(ctx, objectID, action)
+// 	if err != nil {
+// 		entry.WithError(err).Error("failed to update action")
+// 		s.writeError(w, http.StatusBadRequest, fmt.Errorf("failed to update action: %w", err))
+// 		return
+// 	}
 
-	s.writeResponse(w, http.StatusOK, action)
+// 	s.writeResponse(w, http.StatusOK, action)
 
-}
+// }
 
 func (s *server) handleDeleteAction(w http.ResponseWriter, r *http.Request) {
 

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -135,7 +135,7 @@ func (s *server) buildRouter() *chi.Mux {
 			r.Get(newrelic.WrapHandleFunc(s.newrelic, "/actions", s.handleGetActions))
 			r.Post(newrelic.WrapHandleFunc(s.newrelic, "/actions", s.handleCreateAction))
 			r.Post(newrelic.WrapHandleFunc(s.newrelic, "/actions/{actionID}/test", s.handlePostActionTest))
-			r.Patch(newrelic.WrapHandleFunc(s.newrelic, "/actions/{actionID}", s.handleUpdateAction))
+			// r.Patch(newrelic.WrapHandleFunc(s.newrelic, "/actions/{actionID}", s.handleUpdateAction))
 			r.Delete(newrelic.WrapHandleFunc(s.newrelic, "/actions/{actionID}", s.handleDeleteAction))
 			r.Post(newrelic.WrapHandleFunc(s.newrelic, "/rules/validate", s.handlePostValidateRules))
 

--- a/internal/http/redis.go
+++ b/internal/http/redis.go
@@ -1,0 +1,16 @@
+package http
+
+import (
+	"context"
+
+	"github.com/eveisesi/zrule"
+)
+
+func (s *server) restartRedisTracker(ctx context.Context) error {
+	_, err := s.redis.Set(ctx, zrule.QUEUE_RESTART_TRACKER, 1, 0).Result()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/http/search.go
+++ b/internal/http/search.go
@@ -20,12 +20,12 @@ func (s *server) handleGetSearchCategories(w http.ResponseWriter, r *http.Reques
 	// Search is provided for a subset of searchable entities within Eve Online
 	// We cannot facilitate search for Alliaces, Corporations, or Characters
 	// There are just to many in Eve Online, that is why the search service only provides
-	// Regions, Constellations, Systems, Items, and ItemGroups.
+	// Regions, Constellations, Systems, Items, ItemGroups, and Factions.
 	// For Alliaces, Corporations, or Characters, we need to tell the consumer to use
 	// the actual ESI API
 
 	// There are all of the possible search categories per say
-	allCategories := []string{"alliances", "corporations", "characters", "regions", "constellations", "systems", "items", "itemGroups"}
+	allCategories := []string{"alliances", "corporations", "characters", "regions", "constellations", "systems", "items", "itemGroups", "faction"}
 
 	// Get the ones that we provide
 	allKeys := search.AllKeys
@@ -66,7 +66,12 @@ func (s *server) handleGetSearchName(w http.ResponseWriter, r *http.Request) {
 
 	key := r.URL.Query().Get("key")
 	if key == "" {
-		s.writeError(w, http.StatusBadRequest, fmt.Errorf("category query paramater is required to execute a search"))
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("key query paramater is required to execute a search"))
+		return
+	}
+
+	if !search.Key(key).Valid() {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("key is invalid"))
 		return
 	}
 

--- a/internal/mdb/faction.go
+++ b/internal/mdb/faction.go
@@ -1,0 +1,72 @@
+package mdb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/eveisesi/zrule"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx"
+)
+
+type factionRepository struct {
+	factions *mongo.Collection
+}
+
+func NewFactionRepository(d *mongo.Database) (zrule.FactionRepository, error) {
+
+	factions := d.Collection("factions")
+	_, err := factions.Indexes().CreateOne(context.Background(), mongo.IndexModel{Keys: bsonx.Doc{{Key: "id", Value: bsonx.Int32(1)}}, Options: &options.IndexOptions{Name: newString("uniqueFactionID"), Unique: newBool(true)}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize user repository. Error encountered configured collection indexes: %w", err)
+	}
+
+	return &factionRepository{
+		factions: factions,
+	}, nil
+
+}
+
+func (r *factionRepository) Factions(ctx context.Context, operators ...*zrule.Operator) ([]*zrule.Faction, error) {
+
+	filters := BuildFilters(operators...)
+	options := BuildFindOptions(operators...)
+
+	var factions = make([]*zrule.Faction, 0)
+	result, err := r.factions.Find(ctx, filters, options)
+	if err != nil {
+		return factions, err
+	}
+
+	err = result.All(ctx, &factions)
+	return factions, err
+
+}
+
+func (r *factionRepository) Faction(ctx context.Context, id uint) (*zrule.Faction, error) {
+
+	faction := zrule.Faction{}
+
+	err := r.factions.FindOne(ctx, primitive.D{primitive.E{Key: "id", Value: id}}).Decode(&faction)
+
+	return &faction, err
+
+}
+
+func (r *factionRepository) CreateFaction(ctx context.Context, faction *zrule.Faction) (*zrule.Faction, error) {
+
+	faction.CreatedAt = time.Now()
+	faction.UpdatedAt = time.Now()
+
+	_, err := r.factions.InsertOne(ctx, faction)
+	if err != nil {
+		if !IsUniqueConstrainViolation(err) {
+			return nil, err
+		}
+	}
+	return faction, nil
+
+}

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -215,7 +215,6 @@ func (s *service) Run(limit int64) error {
 			s.logger.Info("handling message")
 			// limiter.ExecuteWithTicket(func(workerID int) {
 			s.handleMessage(newrelic.NewContext(ctx, s.newrelic.StartTransaction("handle message").NewGoroutine()), []byte(message))
-			time.Sleep(time.Millisecond * 500)
 			// })
 		}
 

--- a/internal/processor/service.go
+++ b/internal/processor/service.go
@@ -68,7 +68,7 @@ func NewService(
 func (s *service) initializeTracker(ctx context.Context) error {
 	s.logger.Info("starting tracker initialization")
 	defer s.logger.Info("finishing tracker initialization")
-	policies, err := s.policy.Policies(ctx)
+	policies, err := s.policy.Policies(ctx, zrule.NewEqualOperator("paused", false))
 	if err != nil {
 		return err
 	}

--- a/internal/search/const.go
+++ b/internal/search/const.go
@@ -8,10 +8,11 @@ const (
 	KeySystems        Key = "systems"
 	KeyItems          Key = "items"
 	KeyItemGroups     Key = "itemGroups"
+	KeyFactions       Key = "factions"
 )
 
 var AllKeys = []Key{
-	KeyRegions, KeyConstellations, KeySystems, KeyItemGroups, KeyItems,
+	KeyRegions, KeyConstellations, KeySystems, KeyItemGroups, KeyItems, KeyFactions,
 }
 
 func (r Key) String() string {

--- a/internal/universe/service.go
+++ b/internal/universe/service.go
@@ -19,7 +19,7 @@ type Service interface {
 	zrule.RegionRepository
 	zrule.ConstellationRepository
 	zrule.SolarSystemRepository
-
+	zrule.FactionRepository
 	zrule.ItemRepository
 	zrule.ItemGroupRepository
 }
@@ -36,7 +36,7 @@ type service struct {
 	zrule.RegionRepository
 	zrule.ConstellationRepository
 	zrule.SolarSystemRepository
-
+	zrule.FactionRepository
 	zrule.ItemRepository
 	zrule.ItemGroupRepository
 }
@@ -52,7 +52,7 @@ func NewService(
 	region zrule.RegionRepository,
 	constellation zrule.ConstellationRepository,
 	solarSystem zrule.SolarSystemRepository,
-
+	faction zrule.FactionRepository,
 	item zrule.ItemRepository,
 	itemGroup zrule.ItemGroupRepository,
 ) Service {
@@ -68,6 +68,7 @@ func NewService(
 		RegionRepository:        region,
 		ConstellationRepository: constellation,
 		SolarSystemRepository:   solarSystem,
+		FactionRepository:       faction,
 		ItemRepository:          item,
 		ItemGroupRepository:     itemGroup,
 	}

--- a/internal/websocket/service.go
+++ b/internal/websocket/service.go
@@ -58,7 +58,6 @@ func (s *service) Run() error {
 			txn.End()
 			break
 		}
-
 		for {
 
 			_, message, err := conn.ReadMessage()
@@ -84,7 +83,8 @@ func (s *service) Run() error {
 				s.logger.WithError(err).WithField("payload", string(message)).Error("unable to push killmail to processing queue")
 				return err
 			}
-			s.logger.Info("payload dispatched successfully")
+			s.logger.Info("message received")
+
 		}
 	}
 

--- a/killmail.go
+++ b/killmail.go
@@ -1,16 +1,15 @@
 package zrule
 
 import (
-	"context"
 	"time"
 )
 
-type KillmailRepository interface {
-	Killmail(ctx context.Context, id uint) (*Killmail, error)
-	Killmails(ctx context.Context, operators ...*Operator) ([]*Killmail, error)
+// type KillmailRepository interface {
+// 	Killmail(ctx context.Context, id uint) (*Killmail, error)
+// 	Killmails(ctx context.Context, operators ...*Operator) ([]*Killmail, error)
 
-	CreateKillmail(ctx context.Context, killmail *Killmail) error
-}
+// 	CreateKillmail(ctx context.Context, killmail *Killmail) error
+// }
 
 type KillHash struct {
 	ID   uint      `bson:"id" json:"id"`
@@ -19,82 +18,55 @@ type KillHash struct {
 }
 
 type Killmail struct {
-	ID              uint      `bson:"id" json:"id"`
-	Hash            string    `bson:"hash" json:"hash"`
-	MoonID          *uint     `bson:"moonID,omitempty" json:"moonID,omitempty"`
-	SolarSystemID   uint      `bson:"solarSystemID" json:"solarSystemID"`
-	ConstellationID uint      `bson:"constellationID"`
-	RegionID        uint      `bson:"regionID"`
-	WarID           *uint     `bson:"warID,omitempty" json:"warID,omitempty"`
-	IsNPC           bool      `bson:"isNPC" json:"isNPC"`
-	IsAwox          bool      `bson:"isAwox" json:"isAwox"`
-	IsSolo          bool      `bson:"isSolo" json:"isSolo"`
-	DroppedValue    float64   `bson:"droppedValue" json:"droppedValue"`
-	DestroyedValue  float64   `bson:"destroyedValue" json:"destroyedValue"`
-	FittedValue     float64   `bson:"fittedValue" json:"fittedValue"`
-	TotalValue      float64   `bson:"totalValue" json:"totalValue"`
-	KillmailTime    time.Time `bson:"killmailTime" json:"killmailTime"`
+	ID              uint      `json:"killmail_id"`       // bson:"killmail_id"
+	Hash            string    `json:"killmail_hash"`     // bson:"killmail_hash"
+	MoonID          *uint     `json:"moon_id,omitempty"` // bson:"moon_id,o
+	SolarSystemID   uint      `json:"solar_system_id"`   // bson:"solar_system_id"
+	ConstellationID uint      `json:"constellation_id"`
+	RegionID        uint      `json:"region_id"`
+	WarID           *uint     `json:"war_id,omitempty"` // bson:"war_id,o
+	KillmailTime    time.Time `json:"killmail_time"`    // bson:"killmail_time"
 
-	System    *SolarSystem        `bson:"-" json:"-"`
-	Attackers []*KillmailAttacker `bson:"attackers" json:"attackers"`
-	Victim    *KillmailVictim     `bson:"victim" json:"victim"`
+	Attackers []*KillmailAttacker `json:"attackers"` // bson:"attackers"
+	Victim    *KillmailVictim     `json:"victim"`    // bson:"victim"
+	Meta      *Meta               `json:"zkb"`
+}
+
+type Meta struct {
+	LocationID  uint    `json:"locationID"`
+	Hash        string  `json:"hash"`
+	FittedValue float64 `json:"fittedValue"`
+	TotalValue  float64 `json:"totalValue"`
+	Points      uint    `json:"points"`
+	NPC         bool    `json:"npc"`
+	Solo        bool    `json:"bool"`
+	Awox        bool    `json:"awox"`
+	ESI         string  `json:"esi"`
+	URL         string  `json:"url"`
 }
 
 type KillmailAttacker struct {
-	KillmailID     uint    `bson:"killmailID" json:"killmailID"`
-	AllianceID     *uint   `bson:"allianceID" json:"allianceID"`
-	CharacterID    *uint64 `bson:"characterID" json:"characterID"`
-	CorporationID  *uint   `bson:"corporationID" json:"corporationID"`
-	FactionID      *uint   `bson:"factionID" json:"factionID"`
-	DamageDone     uint    `bson:"damageDone" json:"damageDone"`
-	FinalBlow      bool    `bson:"finalBlow" json:"finalBlow"`
-	SecurityStatus float64 `bson:"securityStatus" json:"securityStatus"`
-	ShipTypeID     *uint   `bson:"shipTypeID" json:"shipTypeID"`
-	ShipGroupID    *uint   `bson:"shipGroupID" json:"shipGroupID"`
-	WeaponTypeID   *uint   `bson:"weaponTypeID" json:"weaponTypeID"`
-	WeaponGroupID  *uint   `bson:"weaponGroupID" json:"weaponGroupID"`
-
-	Alliance    *Alliance    `bson:"-" json:"-"`
-	Character   *Character   `bson:"-" json:"-"`
-	Corporation *Corporation `bson:"-" json:"-"`
-	Ship        *Item        `bson:"-" json:"-"`
-	Weapon      *Item        `bson:"-" json:"-"`
-}
-
-type KillmailItem struct {
-	KillmailID        uint    `bson:"killmailID" json:"killmailID"`
-	Flag              uint    `bson:"flag" json:"flag"`
-	ItemTypeID        uint    `bson:"itemTypeID" json:"itemTypeID"`
-	ItemGroupID       uint    `bson:"itemGroupID" json:"itemGroupID"`
-	QuantityDropped   *uint   `bson:"quantityDropped" json:"quantityDropped"`
-	QuantityDestroyed *uint   `bson:"quantityDestroyed" json:"quantityDestroyed"`
-	ItemValue         float64 `bson:"itemValue" json:"itemValue"`
-	TotalValue        float64 `bson:"totalValue" json:"totalValue"`
-	Singleton         uint8   `bson:"singleton" json:"singleton"`
-	IsParent          bool    `bson:"isparent" json:"isparent"`
-
-	Type  *Item           `bson:"-" json:"-"`
-	Items []*KillmailItem `bson:"items" json:"items"`
+	AllianceID     *uint   `json:"alliance_id"`     // bson:"alliance_id"
+	CharacterID    *uint64 `json:"character_id"`    // bson:"character_id"
+	CorporationID  *uint   `json:"corporation_id"`  // bson:"corporation_id"
+	FactionID      *uint   `json:"faction_id"`      // bson:"faction_id"
+	DamageDone     uint    `json:"damage_done"`     // bson:"damage_done"
+	FinalBlow      bool    `json:"final_blow"`      // bson:"final_blow"
+	SecurityStatus float64 `json:"security_status"` // bson:"security_status"
+	ShipTypeID     *uint   `json:"ship_type_id"`    // bson:"ship_type_id"
+	ShipGroupID    *uint   `json:"shipGroupID"`     // bson:"shipGroupID"
+	WeaponTypeID   *uint   `json:"weapon_type_id"`  // bson:"weapon_type_id"
+	WeaponGroupID  *uint   `json:"weaponGroupID"`   // bson:"weaponGroupID"
 }
 
 type KillmailVictim struct {
-	KillmailID    uint    `bson:"killmailID" json:"killmailID"`
-	AllianceID    *uint   `bson:"allianceID" json:"allianceID"`
-	CharacterID   *uint64 `bson:"characterID" json:"characterID"`
-	CorporationID *uint   `bson:"corporationID" json:"corporationID"`
-	FactionID     *uint   `bson:"factionID" json:"factionID"`
-	DamageTaken   uint    `bson:"damageTaken" json:"damageTaken"`
-	ShipTypeID    uint    `bson:"shipTypeID" json:"shipTypeID"`
-	ShipGroupID   uint    `bson:"shipGroupID" json:"shipGroupID"`
-	ShipValue     float64 `bson:"shipValue" json:"shipValue"`
-
-	Alliance    *Alliance    `bson:"-" json:"-"`
-	Character   *Character   `bson:"-" json:"-"`
-	Corporation *Corporation `bson:"-" json:"-"`
-	Ship        *Item        `bson:"-" json:"-"`
-
-	Position *Position       `bson:"position" json:"position"`
-	Items    []*KillmailItem `bson:"items" json:"items"`
+	AllianceID    *uint   `json:"alliance_id"`    // bson:"alliance_id"
+	CharacterID   *uint64 `json:"character_id"`   // bson:"character_id"
+	CorporationID *uint   `json:"corporation_id"` // bson:"corporation_id"
+	FactionID     *uint   `json:"faction_id"`     // bson:"faction_id"
+	DamageTaken   uint    `json:"damage_taken"`   // bson:"damage_taken"
+	ShipTypeID    uint    `json:"ship_type_id"`   // bson:"ship_type_id"
+	ShipGroupID   uint    `json:"ship_group_id"`  // bson:"ship_group_id"
 }
 
 type Position struct {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -144,6 +144,9 @@ func (r *Ruler) ValuesToEvaluate(path string, depth int, v reflect.Value, visite
 		}
 
 	default:
+		if !v.IsValid() {
+			return results
+		}
 		results = append(results, v.Interface())
 		return results
 	}

--- a/policy.go
+++ b/policy.go
@@ -46,17 +46,20 @@ type PathObj struct {
 	Category       PathCategory       `json:"category,omitempty"`
 	Searchable     bool               `json:"searchable"`
 	SearchEndpoint endpoint           `json:"searchEndpoint,omitempty"`
-	Format         string             `json:"format"`
+	Format         format             `json:"format"`
 	Path           Path               `json:"path"`
 	Comparators    []ruler.Comparator `json:"comparators"`
 }
 
-type Path string
+type format string
 type endpoint string
 
 const (
-	EndpointESI endpoint = "esi"
-	EndpointAPI endpoint = "api"
+	endpointESI   endpoint = "esi"
+	endpointAPI   endpoint = "api"
+	formatString  format   = "string"
+	formatNumber  format   = "number"
+	formatBoolean format   = "boolean"
 )
 
 var (
@@ -65,161 +68,257 @@ var (
 		Description:    "The Solar System that the Killmail occurred in",
 		Category:       PathCategorySystems,
 		Searchable:     true,
-		SearchEndpoint: EndpointAPI,
-		Format:         "string",
-		Path:           Path("solar_system_id"),
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Path:           Path("SolarSystemID"),
+		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
+	}
+	PathConstellationID = PathObj{
+		Display:        "Constellation",
+		Description:    "The Constellation that the Killmail occurred in",
+		Category:       PathCategoryConstellations,
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Path:           Path("ConstellationID"),
+		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
+	}
+	PathRegionID = PathObj{
+		Display:        "Region",
+		Description:    "The Region that the Killmail occurred in",
+		Category:       PathCategoryRegions,
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Path:           Path("RegionID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 	PathZKBNPC = PathObj{
 		Display:     "ZKillboard Is NPC",
 		Description: "ZKillboard has labeled the killmail as an NPC Kill",
-		Searchable:  false,
-		Format:      "boolean",
-		Path:        Path("zkb.npc"),
+		Format:      formatBoolean,
+		Path:        Path("Meta.NPC"),
 		Comparators: []ruler.Comparator{ruler.EQ},
 	}
 	PathZKBAWOX = PathObj{
 		Display:     "ZKillboard Is AWOX",
 		Description: "Zkillboard has labeled the killmail as an AWOX Kill",
-		Searchable:  false,
-		Format:      "boolean",
-		Path:        Path("zkb.awox"),
+		Format:      formatBoolean,
+		Path:        Path("Meta.AWOX"),
 		Comparators: []ruler.Comparator{ruler.EQ},
 	}
 	PathZKBSolo = PathObj{
 		Display:     "ZKillboard Is Solo",
 		Description: "ZKIllboard has labeled the killmail as a Solo Kill",
-		Searchable:  false,
-		Format:      "boolean",
-		Path:        Path("zkb.solo"),
+		Format:      formatBoolean,
+		Path:        Path("Meta.Solo"),
 		Comparators: []ruler.Comparator{ruler.EQ},
 	}
 	PathZKBFittedValue = PathObj{
 		Display:     "Zkillboard Fitted Value",
 		Description: "The ISK value of all modules and ammo fitted to the ship",
-		Searchable:  false,
-		Format:      "number",
-		Path:        Path("zkb.fittedValue"),
+		Format:      formatNumber,
+		Path:        Path("Meta.FittedValue"),
 		Comparators: []ruler.Comparator{ruler.EQ, ruler.GT, ruler.GTE, ruler.LT, ruler.LTE},
 	}
 	PathZKBTotalValue = PathObj{
 		Display:     "ZKillboard Total Value",
 		Description: "The ISK value of the killmail",
-		Searchable:  false,
-		Format:      "number",
-		Path:        Path("zkb.totalValue"),
+		Format:      formatNumber,
+		Path:        Path("Meta.TotalValue"),
 		Comparators: []ruler.Comparator{ruler.EQ, ruler.GT, ruler.GTE, ruler.LT, ruler.LTE},
+	}
+	PathWarID = PathObj{
+		Display:     "War ID",
+		Description: "The ID of the war that this killmail is involved in.",
+		Format:      formatNumber,
+		Path:        Path("WarID"),
+		Comparators: []ruler.Comparator{ruler.EQ},
 	}
 	PathVictimAllianceID = PathObj{
 		Display:        "Victim Alliance",
-		Description:    "The alliance that the victim is apart of",
+		Description:    "The alliance that the victim is/was apart of at the time of the kill",
 		Searchable:     true,
-		SearchEndpoint: EndpointESI,
-		Format:         "string",
+		SearchEndpoint: endpointESI,
+		Format:         formatString,
 		Category:       PathCategoryAlliance,
-		Path:           Path("victim.alliance_id"),
+		Path:           Path("Victim.AllianceID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 	PathVictimCorporationID = PathObj{
 		Display:        "Victim Corporation",
-		Description:    "The Corporation that the victim is apart of",
+		Description:    "The Corporation that the victim is/was apart of at the time of the kill",
 		Searchable:     true,
-		SearchEndpoint: EndpointESI,
-		Format:         "string",
+		SearchEndpoint: endpointESI,
+		Format:         formatString,
 		Category:       PathCategoryCorporation,
-		Path:           Path("victim.corporation_id"),
+		Path:           Path("Victim.CorporationID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 	PathVictimCharacterID = PathObj{
 		Display:        "Victim Character",
-		Description:    "The Victim",
+		Description:    "The Victims Character",
 		Searchable:     true,
-		SearchEndpoint: EndpointESI,
-		Format:         "string",
+		SearchEndpoint: endpointESI,
+		Format:         formatString,
 		Category:       PathCategoryCharacter,
-		Path:           Path("victim.character_id"),
+		Path:           Path("Victim.CharacterID"),
+		Comparators:    []ruler.Comparator{ruler.EQ},
+	}
+	PathVictimFactionID = PathObj{
+		Display:        "Victim Faction",
+		Description:    "The Faction that the Character belongs to",
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Category:       PathCategoryFaction,
+		Path:           Path("Victim.FactionID"),
 		Comparators:    []ruler.Comparator{ruler.EQ},
 	}
 	PathVictimShipTypeID = PathObj{
 		Display:        "Victim Ship",
-		Description:    "The ship that the victim was flying",
+		Description:    "The ship that the victim was flying at the time of loss",
 		Searchable:     true,
-		SearchEndpoint: EndpointAPI,
-		Format:         "string",
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
 		Category:       PathCategoryItems,
-		Path:           Path("victim.ship_type_id"),
+		Path:           Path("Victim.ShipTypeID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
+	}
+	PathVictimShipGroupID = PathObj{
+		Display:        "Victim Ship Group",
+		Description:    "The group that the ship that the victim was flying belongs to",
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Category:       PathCategoryItemGroups,
+		Path:           Path("Victim.ShipGroupID"),
+		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
+	}
+	PathVictimDamageTaken = PathObj{
+		Display:     "Victim Damange Sustained",
+		Description: "The amount of damage applied to the ship",
+		Format:      formatNumber,
+		Category:    PathCategoryDamageTaken,
+		Path:        Path("Victim.DamageTaken"),
+		Comparators: []ruler.Comparator{ruler.EQ, ruler.GT, ruler.GTE, ruler.LT, ruler.LTE},
 	}
 	PathAttackerAllianceID = PathObj{
 		Display:        "Attacker Alliance",
-		Description:    "The alliance that the attacker belongs to",
+		Description:    "The alliance that the attacker is/was apart of at the time of the kill",
 		Searchable:     true,
-		SearchEndpoint: EndpointESI,
-		Format:         "string",
+		SearchEndpoint: endpointESI,
+		Format:         formatString,
 		Category:       PathCategoryAlliance,
-		Path:           Path("attackers.alliance_id"),
+		Path:           Path("Attackers.AllianceID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 	PathAttackerCorporationID = PathObj{
 		Display:        "Attacker Corporation",
-		Description:    "The corporation that the attacker belongs to",
+		Description:    "The corporation that the attacker is/was apart of at the time of the kill",
 		Searchable:     true,
-		SearchEndpoint: EndpointESI,
-		Format:         "string",
+		SearchEndpoint: endpointESI,
+		Format:         formatString,
 		Category:       PathCategoryCorporation,
-		Path:           Path("attackers.corporation_id"),
+		Path:           Path("Attackers.CorporationID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 	PathAttackerCharacterID = PathObj{
 		Display:        "Attacker Character",
-		Description:    "The Attacker",
+		Description:    "The Attacker Character",
 		Searchable:     true,
-		SearchEndpoint: EndpointESI,
-		Format:         "string",
+		SearchEndpoint: endpointESI,
+		Format:         formatString,
 		Category:       PathCategoryCharacter,
-		Path:           Path("attackers.character_id"),
+		Path:           Path("Attackers.CharacterID"),
 		Comparators:    []ruler.Comparator{ruler.EQ},
+	}
+	PathAttackerFactionID = PathObj{
+		Display:        "Attacker Faction",
+		Description:    "The faction that the attacker is/was apart of at the time of the kill",
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Category:       PathCategoryFaction,
+		Path:           Path("Attackers.FactionID"),
+		Comparators:    []ruler.Comparator{ruler.EQ},
+	}
+	PathAttackersDamageDone = PathObj{
+		Display:     "Attacker Damage Done",
+		Description: "The amount of damage this attacker dealt to the victim",
+		Format:      formatNumber,
+		Category:    PathCategoryDamageDone,
+		Path:        Path("Attackers.DamageDone"),
+		Comparators: []ruler.Comparator{ruler.GT, ruler.GTE, ruler.LT, ruler.LTE},
 	}
 	PathAttackerShipTypeID = PathObj{
 		Display:        "Attacker Ship",
-		Description:    "The Ship that the attacker was flying",
+		Description:    "The Ship that the attacker was flying at the time of the kill",
 		Searchable:     true,
-		SearchEndpoint: EndpointAPI,
-		Format:         "string",
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
 		Category:       PathCategoryItems,
-		Path:           Path("attackers.ship_type_id"),
+		Path:           Path("Attackers.ShipTypeID"),
+		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
+	}
+	PathAttackerShipGroupID = PathObj{
+		Display:        "Attacker Ship Group",
+		Description:    "The group of the ship that the attacker was flying at the time of the kill",
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Category:       PathCategoryItemGroups,
+		Path:           Path("Attackers.ShipGroupID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 	PathAttackerWeaponTypeID = PathObj{
 		Display:        "Attacker Weapon",
-		Description:    "The weapon that the attacker used",
+		Description:    "The weapon that the attacker used during the kill",
 		Searchable:     true,
-		SearchEndpoint: EndpointAPI,
-		Format:         "string",
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
 		Category:       PathCategoryItems,
-		Path:           Path("attackers.weapon_type_id"),
+		Path:           Path("Attackers.WeaponTypeID"),
+		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
+	}
+	PathAttackerWeaponGroupID = PathObj{
+		Display:        "Attacker Weapon Group",
+		Description:    "The group of the weapon that the attacker was using at the time of the kill",
+		Searchable:     true,
+		SearchEndpoint: endpointAPI,
+		Format:         formatString,
+		Category:       PathCategoryItemGroups,
+		Path:           Path("Attackers.WeaponGroupID"),
 		Comparators:    []ruler.Comparator{ruler.EQ, ruler.NEQ},
 	}
 )
 
 var AllPaths = []PathObj{
 	PathSolarSystemID,
+	PathConstellationID,
+	PathRegionID,
 	PathZKBNPC,
 	PathZKBAWOX,
 	PathZKBSolo,
 	PathZKBFittedValue,
 	PathZKBTotalValue,
+	PathWarID,
 	PathVictimAllianceID,
 	PathVictimCorporationID,
 	PathVictimCharacterID,
+	PathVictimFactionID,
 	PathVictimShipTypeID,
-	// PathVictimItemsTypeID,
 	PathAttackerAllianceID,
 	PathAttackerCorporationID,
 	PathAttackerCharacterID,
+	PathAttackerFactionID,
 	PathAttackerShipTypeID,
+	PathAttackerShipGroupID,
 	PathAttackerWeaponTypeID,
+	PathAttackerWeaponGroupID,
 }
+
+type Path string
 
 func (p Path) IsValid() bool {
 	for _, v := range AllPaths {
@@ -240,16 +339,22 @@ const (
 	PathCategoryAlliance       PathCategory = "alliance"
 	PathCategoryCorporation    PathCategory = "corporation"
 	PathCategoryCharacter      PathCategory = "character"
+	PathCategoryFaction        PathCategory = "factions"
 	PathCategoryRegions        PathCategory = "regions"
 	PathCategoryConstellations PathCategory = "constellations"
 	PathCategorySystems        PathCategory = "systems"
 	PathCategoryItems          PathCategory = "items"
+	PathCategoryItemGroups     PathCategory = "itemGroups"
+	PathCategoryDamageTaken    PathCategory = "damageTaken"
+	PathCategoryDamageDone     PathCategory = "damageDone"
 )
 
 var AllPathCategories = []PathCategory{
 	PathCategoryAlliance, PathCategoryCorporation, PathCategoryCharacter,
 	PathCategoryRegions, PathCategoryConstellations, PathCategorySystems,
-	PathCategoryItems,
+	PathCategoryItems, PathCategoryItemGroups,
+	PathCategoryDamageDone, PathCategoryDamageTaken,
+	PathCategoryFaction,
 }
 
 func (p PathCategory) IsValid() bool {

--- a/policy.go
+++ b/policy.go
@@ -28,6 +28,7 @@ type Policy struct {
 	OwnerID   primitive.ObjectID   `bson:"owner_id" json:"owner_id"`
 	Rules     [][]*Rule            `bson:"rules" json:"rules"`
 	Actions   []primitive.ObjectID `bson:"actions" json:"actions"`
+	Paused    bool                 `bson:"paused" json:"paused"`
 	CreatedAt time.Time            `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time            `bson:"updated_at" json:"updated_at"`
 }

--- a/universe.go
+++ b/universe.go
@@ -31,6 +31,21 @@ type Character struct {
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
 }
 
+type FactionRepository interface {
+	Faction(ctx context.Context, id uint) (*Faction, error)
+	Factions(ctx context.Context, operators ...*Operator) ([]*Faction, error)
+	CreateFaction(ctx context.Context, faction *Faction) (*Faction, error)
+}
+
+type Faction struct {
+	ID            uint      `bson:"id" json:"id"`
+	ESIID         uint      `bson:"-" json:"faction_id"`
+	Name          string    `bson:"name" json:"name"`
+	CorporationID uint      `bson:"corporation_id" json:"corporation_id"`
+	CreatedAt     time.Time `bson:"created_at" json:"created_at"`
+	UpdatedAt     time.Time `bson:"updated_at" json:"updated_at"`
+}
+
 type ConstellationRepository interface {
 	Constellations(ctx context.Context, operators ...*Operator) ([]*Constellation, error)
 	Constellation(ctx context.Context, id uint) (*Constellation, error)


### PR DESCRIPTION
This PR is a refactor of the Processor that is responsible for comparing inbound killmails with stored policies. There are a number of other changes introduced in this PR that address comments received after initial release.

Changes In this PR:
 - NewRelic is now transaction heavy in the WebSocket, Dispatcher, and Processor, we may revert this later on, but I want to see what the outcome of this is. My intention is to use Apdex to alert on inactivity maybe.
 - 
ESI Service
 - Added Support for fetching factions
Server
 - Removed the ability to update actions. The UI does not support this and there are minimal updates that can be done.
 - Added factions as a target for Search
MDB
 - Added Support for fetching and creating faction records

Pausing a Policy
Policies can now be paused. This is accomplished by adding a paused property to the Policy Struct and when querying for policies from this collection, we query where this value is false.

Processor
 - I am removing the limiter right now to remove concurrency. I want to see what impact this has overall

Logging
 - Removed log spam. We now only output to the logs when some significant is happening.

Ruler
 - Ruler now supports passed in a struct. This allows use to pass in the zrule.Killmail struct that is hydrated with additional information so that additional rules can be created against the killmail. This address a request we received to allow for Region and/or Constellations and Faction Warfare.

